### PR TITLE
Change repo name for custom pelican-bootstrap3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "theme/pelican-bootstrap3"]
 	path = theme/pelican-bootstrap3
-	url = git@github.com:StevenMaude/pelican-bootstrap3-my-blog.git
+	url = git@github.com:StevenMaude/pelican-bootstrap3-sm.git


### PR DESCRIPTION
Catchier title: sm can refer to it being a submodule, or my initials.