### PR TITLE
Fix tag cloud in 3.6.0

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -25,7 +25,7 @@ DEFAULT_PAGINATION = 10
 # Uncomment following line if you want document-relative URLs when developing
 RELATIVE_URLS = True
 
-PLUGINS = ['pelican_alias', ]
+PLUGINS = ['pelican_alias', 'tag_cloud']
 MD_EXTENSIONS = ['codehilite(css_class=highlight)', 'extra', 'admonition']
 
 THEME = 'theme/pelican-bootstrap3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pelican==3.6.0
 pelican-alias==1.0
+git+https://github.com/StevenMaude/pelican-tag-cloud.git@4afca64c40daaeb72a26c573ef8b11507a2811e1#egg=tag-cloud

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pelican>=3.5.0
-pelican-alias>=1.0
+pelican==3.6.0
+pelican-alias==1.0


### PR DESCRIPTION
Pelican 3.6.0 moved out the tag cloud generation to a plugin and so my site tags weren't being displayed in the sidebar.

Rather than have to clone the entire [pelican-plugins](https://github.com/getpelican/pelican-plugins) repo, I've opted to fork and make that single plugin `pip` installable.

This has the advantage of being **much** smaller, and the plugin dependency is pinned.