### PR TITLE
Use toc Markdown extension

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -26,7 +26,8 @@ DEFAULT_PAGINATION = 10
 RELATIVE_URLS = True
 
 PLUGINS = ['pelican_alias', 'tag_cloud']
-MD_EXTENSIONS = ['codehilite(css_class=highlight)', 'extra', 'admonition']
+MD_EXTENSIONS = ['codehilite(css_class=highlight)', 'extra', 'admonition',
+                 'toc']
 
 THEME = 'theme/pelican-bootstrap3'
 


### PR DESCRIPTION
Don't want a table of contents necessarily, but it does add an id to
each header, which is useful for linking sections with a document.