### PR TITLE
Update pelican-bootstrap3-sm theme to latest

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -29,7 +29,7 @@ PLUGINS = ['pelican_alias', 'tag_cloud', 'i18n_subsites']
 MD_EXTENSIONS = ['codehilite(css_class=highlight)', 'extra', 'admonition',
                  'toc']
 
-THEME = 'theme/pelican-bootstrap3'
+THEME = 'theme/pelican-bootstrap3/pelican-bootstrap3'
 
 STATIC_PATHS = ['images']
 STATIC_EXCLUDES = ['images/.git']


### PR DESCRIPTION
Following StevenMaude/pelican-bootstrap3-sm#12.

This also changes the theme location.

Due to the theme moving to the getpelican/pelican-themes repository, and
becoming a subdirectory, it was easier to get commits to apply via
`git cherry-pick` when the structure was the same. The result of this is
that the path has changed here too.