### PR TITLE
Ignore gh-pages directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cache
 output
 content
 *.pid
+gh-pages


### PR DESCRIPTION
Used for pushing changed output of Pelican to GitHub. No need to store
it in blog-config.