### PR TITLE
Comment out tags menuitem in config

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -39,7 +39,7 @@ MARKDOWN = {
 THEME = 'theme/pelican-bootstrap3/pelican-bootstrap3'
 
 PADDED_SINGLE_COLUMN_STYLE = True
-MENUITEMS = [('Tags', 'tags')]
+#MENUITEMS = [('Tags', 'tags')]
 
 STATIC_PATHS = ['images']
 STATIC_EXCLUDES = ['images/.git']


### PR DESCRIPTION
The problem is that this is a relative link, meaning that it is broken
when clicking on "Tags" when visiting an article page.

Don't think there is a way to specify a relative link here, see
https://github.com/getpelican/pelican/issues/2272

The easiest fix is to remove the link, and reduces clutter on the page.