### PR TITLE
Remove Twitter configuration

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -130,6 +130,5 @@ OPEN_GRAPH_IMAGE = 'images/extra/site_open_graph.png'
 TWITTER_USERNAME = "StevenMaude"
 TWITTER_CARDS = True
 
-FOOTER_SOCIAL = (('Twitter', 'https://twitter.com/StevenMaude'),
-                 ('GitHub', 'https://github.com/StevenMaude'),
+FOOTER_SOCIAL = (('GitHub', 'https://github.com/StevenMaude'),
                  ('LinkedIn', 'https://linkedin.com/in/StevenMaude'),)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -127,7 +127,6 @@ EXTRA_PATH_METADATA = {
 
 # Open Graph
 OPEN_GRAPH_IMAGE = 'images/extra/site_open_graph.png'
-TWITTER_USERNAME = "StevenMaude"
 TWITTER_CARDS = True
 
 FOOTER_SOCIAL = (('GitHub', 'https://github.com/StevenMaude'),


### PR DESCRIPTION
`TWITTER_CARDS` can still function even without a Twitter username
provided.

So leaving that as is for now.